### PR TITLE
[NRL-602] Remove spaces from catch all error message

### DIFF
--- a/proxies/live/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
@@ -10,7 +10,7 @@
             "details": {
                 "coding": [ {
                     "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
-                    "code": "FAILURE_TO_PROCESS_MESSAGE	"
+                    "code": "FAILURE_TO_PROCESS_MESSAGE"
                     "display": "Failure to process message"
                 } ]
             },

--- a/proxies/sandbox/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
+++ b/proxies/sandbox/apiproxy/policies/AssignMessage.Errors.CatchAllMessage.xml
@@ -10,7 +10,7 @@
             "details": {
                 "coding": [ {
                     "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
-                    "code": "FAILURE_TO_PROCESS_MESSAGE	"
+                    "code": "FAILURE_TO_PROCESS_MESSAGE"
                     "display": "Failure to process message"
                 } ]
             },


### PR DESCRIPTION
## Summary
* Routine Change

While testing, we noticed that the catch all error code had a space/tab character inside the quotes. This is invalid so this PR removes that invalid character.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
