### PR TITLE
[NRL-796] Make X-Request-Id a required header for all API requests

### DIFF
--- a/proxies/live/apiproxy/policies/RaiseFault.400MissingRequestIdHeader.xml
+++ b/proxies/live/apiproxy/policies/RaiseFault.400MissingRequestIdHeader.xml
@@ -1,0 +1,26 @@
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400MissingRequestIdHeader">
+    <FaultResponse>
+        <Set>
+            <Payload contentType="application/json">
+            {
+                "resourceType": "OperationOutcome",
+                "issue": [ {
+                    "severity": "error",
+                    "code": "invalid",
+                    "details": {
+                        "coding": [ {
+                            "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
+                            "code": "MISSING_OR_INVALID_HEADER",
+                            "display": "There is a required header missing or invalid"
+                        } ]
+                    },
+                    "diagnostics": "The X-Request-Id header is missing or invalid"
+                } ]
+            }
+            </Payload>
+            <StatusCode>400</StatusCode>
+            <ReasonPhrase>Bad Request</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -28,6 +28,14 @@
       <Condition>(proxy.pathsuffix MatchesPath "/_status") and ((request.verb = "GET") or (request.verb = "HEAD"))
       </Condition>
     </Flow>
+    <Flow name="Raise400ForMissingRequestIdHeader">
+      <Request>
+        <Step>
+          <Name>RaiseFault.400MissingRequestIdHeader</Name>
+        </Step>
+      </Request>
+      <Condition>request.verb != "OPTIONS" and (request.header.X-Request-Id = null or request.header.X-Request-Id = "")</Condition>
+    </Flow>
     <Flow name="Raise400ForMissingODSHeader">
       <Request>
         <Step>

--- a/proxies/sandbox/apiproxy/policies/RaiseFault.400MissingRequestIdHeader.xml
+++ b/proxies/sandbox/apiproxy/policies/RaiseFault.400MissingRequestIdHeader.xml
@@ -1,0 +1,26 @@
+<RaiseFault async="false" continueOnError="false" enabled="true" name="RaiseFault.400MissingRequestIdHeader">
+    <FaultResponse>
+        <Set>
+            <Payload contentType="application/json">
+            {
+                "resourceType": "OperationOutcome",
+                "issue": [ {
+                    "severity": "error",
+                    "code": "invalid",
+                    "details": {
+                        "coding": [ {
+                            "system": "https://fhir.nhs.uk/CodeSystem/Spine-ErrorOrWarningCode",
+                            "code": "MISSING_OR_INVALID_HEADER",
+                            "display": "There is a required header missing or invalid"
+                        } ]
+                    },
+                    "diagnostics": "The X-Request-Id header is missing or invalid"
+                } ]
+            }
+            </Payload>
+            <StatusCode>400</StatusCode>
+            <ReasonPhrase>Bad Request</ReasonPhrase>
+        </Set>
+    </FaultResponse>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/proxies/sandbox/apiproxy/proxies/default.xml
+++ b/proxies/sandbox/apiproxy/proxies/default.xml
@@ -29,6 +29,14 @@
       <Condition>(proxy.pathsuffix MatchesPath "/_status") and ((request.verb = "GET") or (request.verb = "HEAD"))
       </Condition>
     </Flow>
+    <Flow name="Raise400ForMissingRequestIdHeader">
+      <Request>
+        <Step>
+          <Name>RaiseFault.400MissingRequestIdHeader</Name>
+        </Step>
+      </Request>
+      <Condition>request.verb != "OPTIONS" and (request.header.X-Request-Id = null or request.header.X-Request-Id = "")</Condition>
+    </Flow>
     <Flow name="Raise400ForMissingODSHeader">
       <Request>
         <Step>


### PR DESCRIPTION
## Summary
* :exclamation: Breaking Change

Once this PR is merged, all requests will require a X-Request-Id header to be provided with each API request.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
